### PR TITLE
blueprint_*_name funcs refer to _final_ now

### DIFF
--- a/R/blueprint.R
+++ b/R/blueprint.R
@@ -126,7 +126,7 @@ blueprint_target_name.default <- function(x, ...) {
 #' @rdname blueprint_target_name
 #' @export
 blueprint_target_name.character <- function(x, ...) {
-  paste0(x, "_initial")
+  paste0(blueprint_final_name(x), "_initial")
 }
 
 #' @rdname blueprint_target_name
@@ -150,7 +150,7 @@ blueprint_checks_name.default <- function(x, ...) {
 #' @rdname blueprint_target_name
 #' @export
 blueprint_checks_name.character <- function(x, ...) {
-  paste0(x, "_checks")
+  paste0(blueprint_final_name(x), "_checks")
 }
 
 #' @rdname blueprint_target_name
@@ -198,7 +198,7 @@ blueprint_reference_name.default <- function(x, ...) {
 #' @rdname blueprint_target_name
 #' @export
 blueprint_reference_name.character <- function(x, ...) {
-  paste0(x, "_blueprint")
+  paste0(blueprint_final_name(x), "_blueprint")
 }
 
 #' @rdname blueprint_target_name


### PR DESCRIPTION
Addresses #7 

### Description of changes:
- All `blueprint_*_name()` functions refer to `blueprint_final_name()` to reduce name variability. In the future, `blueprint_final_name()` will ensure that `blueprint$name` is syntactically valid to not cause headaches in the drake plan.

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
