### PR TITLE
Ensure that blueprints w/o dependencies yields character(), not NA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blueprintr
 Title: Automagically Document and Test Datasets Using Drake
-Version: 0.0.2
+Version: 0.0.2.9000
 Authors@R: 
     c(person(given = "Patrick",
              family = "Anker",

--- a/R/macros.R
+++ b/R/macros.R
@@ -96,7 +96,7 @@ blueprint_deps <- function(blueprint) {
   command_ast <- extract_ast(blueprint$command)
 
   target_calls <- find_ast_if(command_ast, target_call_check)
-  target_names <- unlist(target_calls)
+  target_names <- flatten_deps_search_stack(target_calls)
 
   if (is.null(target_names)) {
     return(character())
@@ -111,4 +111,15 @@ target_call_check <- function(ast) {
   } else {
     FALSE
   }
+}
+
+flatten_deps_search_stack <- function(list_str) {
+  if (!is.list(list_str)) {
+    return(list_str)
+  }
+
+  list_els <- vlapply(list_str, is.list)
+
+  list_str[list_els] <- lapply(list_str[list_els], flatten_deps_search_stack)
+  unlist(list_str)
 }

--- a/tests/testthat/test-blueprints.R
+++ b/tests/testthat/test-blueprints.R
@@ -19,7 +19,7 @@ test_that("blueprint tests are run", {
       df$mpg <- NULL
       df
     },
-    metadata_file_path = 
+    metadata_file_path =
       file.path(
         bp_path("blueprints"),
         "mtcars_chunk.csv"
@@ -58,9 +58,9 @@ test_that("Dependencies are handled properly", {
         grade = c(4, 5, 5)
       )
 
-      demos %>% 
+      demos %>%
         dplyr::left_join(
-          ids %>% 
+          ids %>%
             dplyr::select(student_id, classroom_id),
           by = "student_id"
         )
@@ -72,6 +72,7 @@ test_that("Dependencies are handled properly", {
     unlink(metadata_path(student_demo_bp))
   }
 
+  expect_identical(blueprint_deps(id_bp), character())
   expect_identical(blueprint_deps(student_demo_bp), "id_vars")
 
   plan <- plan_from_blueprint(id_bp) %>%


### PR DESCRIPTION
Addresses #13 

### Description of changes:
- Created `flatten_deps_search_stack()` to manually address a nested empty list problem in R < 3.5.1 (see [Bug Fixes for 3.5.1](https://cran.r-project.org/doc/manuals/r-devel/NEWS.3.html))

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
