### PR TITLE
Fix rcoder dependency message and read_csv message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 URL: https://github.com/Global-TIES-for-Children/blueprintr
 BugReports: https://github.com/Global-TIES-for-Children/blueprintr/issues
 Depends: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blueprintr
 Title: Automagically Document and Test Datasets Using Drake
-Version: 0.0.2
+Version: 0.0.3.9000
 Authors@R: 
     c(person(given = "Patrick",
              family = "Anker",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# Development version (0.0.3.9000)
+
 # blueprintr 0.0.2
 
 * Created codebook export feature with `render_codebook()` (#3)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -132,7 +132,11 @@ load_metadata <- function(blueprint) {
     bp_err("No metadata exists to load for {blueprint$name}")
   }
 
-  metadata_df <- readr::read_csv(metadata_path(blueprint))
+  metadata_df <-
+    readr::read_csv(
+      metadata_path(blueprint),
+      col_types = readr::cols()
+    )
 
   metadata(metadata_df)
 }

--- a/R/render-codebook.R
+++ b/R/render-codebook.R
@@ -31,7 +31,7 @@ render_codebook <- function(blueprint,
   }
 
   if (!requireNamespace("kableExtra", quietly = TRUE)) {
-    bp_err("rcoder must be installed to render codebooks")
+    bp_err("kableExtra must be installed to render codebooks")
   }
 
   if (!dir.exists(dirname(file))) {

--- a/inst/codebook_templates/default_codebook.Rmd
+++ b/inst/codebook_templates/default_codebook.Rmd
@@ -249,11 +249,6 @@ write_sections <- function(meta, data) {
 stopifnot(is.data.frame(params$dataset) || is.null(params$dataset))
 stopifnot(inherits(params$blueprint, "blueprint")) 
 stopifnot(inherits(params$meta, "blueprint_metadata"))
-
-
-if (!requireNamespace("rcoder", quietly = TRUE)) {
-  bp_err("rcoder must be installed to render codebooks")
-}
 ```
 
 ```{r output, echo=FALSE, results='asis'}

--- a/tests/testthat/test-codebook-export.R
+++ b/tests/testthat/test-codebook-export.R
@@ -51,3 +51,33 @@ test_that("Codebook exports are added to plan correctly", {
     bquote(knitr_in(.(random_template_location)))
   )
 })
+
+test_that("Codebooks are rendered safely", {
+  test_bp <- blueprint(
+    "mtcars_chunk_rearranged",
+    command = mtcars,
+    metadata_directory = bp_path("blueprints")
+  )
+
+  plan <- plan_from_blueprint(test_bp)
+
+  drake::clean()
+  drake::make(plan)
+
+  drake::loadd(mtcars_chunk_rearranged_blueprint)
+  drake::loadd(mtcars_chunk_rearranged_meta)
+
+  temp_file <- file.path(tempdir(), "mtcars_chunk_rearranged.html")
+
+  render_out <- tryCatch(
+    render_codebook(
+      mtcars_chunk_rearranged_blueprint,
+      mtcars_chunk_rearranged_meta,
+      temp_file
+    ),
+    error = function(e) e
+  )
+
+  expect_true(!inherits(render_out, "error"))
+  unlink(temp_file)
+})


### PR DESCRIPTION
Addresses a confusing error message that would show up if kableExtra was not installed. blueprintr would complain that rcoder wasn't installed. Silly typo.

### Description of changes:
- Fix typo in error message during codebook render
- Remove annoying readr::read_csv message when loading metadata file

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
