### PR TITLE
Add recursive blueprint loading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blueprintr
 Title: Automagically Document and Test Datasets Using Drake
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: 
     c(person(given = "Patrick",
              family = "Anker",
@@ -43,5 +43,6 @@ Imports:
     purrr,
     dplyr,
     magrittr,
-    readr
+    readr,
+    fs
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# blueprintr 0.0.7
+
+* Adds `recurse` parameter to `load_blueprints()` and `tar_blueprints()` to recursively load blueprints from the provided `directory`
+
 # blueprintr 0.0.6
 
 * Integration with `panelcleaner` to import homogenized codings if target data.frame is a `mapped_df`

--- a/R/tar_blueprint.R
+++ b/R/tar_blueprint.R
@@ -10,6 +10,7 @@
 #' @param ... Arguments passed to `blueprint()`
 #' @param directory A folder containing R scripts that evaluate to `blueprint()`
 #'                  objects
+#' @param recurse Recursively loads blueprints from a directory if `TRUE`
 #' @return A `list()` of `tar_target` objects
 #'
 #' @export
@@ -22,8 +23,12 @@ tar_blueprint <- function(...) {
 
 #' @rdname tar_blueprint
 #' @export
-tar_blueprints <- function(directory = here::here("blueprints")) {
-  bp_list <- fetch_blueprint_files(directory)
+tar_blueprints <- function(
+  directory = here::here("blueprints"),
+  recurse = FALSE
+) {
+  dirs <- load_dirs_recurse(directory, recurse)
+  bp_list <- fetch_blueprints_from_dir(dirs)
 
   if (is.null(bp_list)) {
     return(list())

--- a/inst/blueprints/subdir_test/test_subdir_blueprint.R
+++ b/inst/blueprints/subdir_test/test_subdir_blueprint.R
@@ -1,0 +1,5 @@
+blueprint(
+  "test_subdir_blueprint",
+  description = "This is a test",
+  command = mtcars
+)

--- a/man/blueprintr-package.Rd
+++ b/man/blueprintr-package.Rd
@@ -17,8 +17,8 @@ Documents and tests datasets in a reproducible
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/Global-TIES-for-Children/blueprintr}
-  \item Report bugs at \url{https://github.com/Global-TIES-for-Children/blueprintr/issues}
+  \item \url{https://github.com/nyuglobalties/blueprintr}
+  \item Report bugs at \url{https://github.com/nyuglobalties/blueprintr/issues}
 }
 
 }

--- a/man/load_blueprint.Rd
+++ b/man/load_blueprint.Rd
@@ -7,7 +7,7 @@
 \usage{
 load_blueprint(plan, file)
 
-load_blueprints(plan, directory = here::here("blueprints"))
+load_blueprints(plan, directory = here::here("blueprints"), recurse = FALSE)
 }
 \arguments{
 \item{plan}{A drake plan}
@@ -17,6 +17,8 @@ load_blueprints(plan, directory = here::here("blueprints"))
 \item{directory}{A path to a directory with script files that are blueprints.
 Defaults to the "blueprints" directory at the root of the
 current R project.}
+
+\item{recurse}{Recursively loads blueprints from a directory if \code{TRUE}}
 }
 \value{
 A drake_plan with attached blueprints

--- a/man/tar_blueprint.Rd
+++ b/man/tar_blueprint.Rd
@@ -7,13 +7,15 @@
 \usage{
 tar_blueprint(...)
 
-tar_blueprints(directory = here::here("blueprints"))
+tar_blueprints(directory = here::here("blueprints"), recurse = FALSE)
 }
 \arguments{
 \item{...}{Arguments passed to \code{blueprint()}}
 
 \item{directory}{A folder containing R scripts that evaluate to \code{blueprint()}
 objects}
+
+\item{recurse}{Recursively loads blueprints from a directory if \code{TRUE}}
 }
 \value{
 A \code{list()} of \code{tar_target} objects

--- a/tests/testthat/test-02-load-blueprints.R
+++ b/tests/testthat/test-02-load-blueprints.R
@@ -23,8 +23,11 @@ test_that("blueprint file fetching works correctly", {
     command = mtcars
   )
 
-  bps <- fetch_blueprint_files(bp_path("blueprints"))
-  expect_true(is.list(bps))
+  bp_files <- fetch_blueprint_files(bp_path("blueprints"))
+  expect_true(is.character(bp_files))
+
+  bps <- lapply(bp_files, import_blueprint_file)
+
   expect_true(!inherits(bps, "blueprint"))
   expect_true(all(vlapply(bps, is_blueprint)))
 
@@ -51,4 +54,20 @@ test_that("Loading from directory works", {
 
   expect_true("test_blueprint_initial" %in% plan$target)
   expect_true("test_blueprint" %in% plan$target)
+})
+
+test_that("Recursively loading from directory works", {
+  plan <- drake::drake_plan(dummy = 1:5)
+
+  plan <-
+    plan %>%
+    load_blueprints(
+      directory = bp_path("blueprints"),
+      recurse = TRUE
+    )
+
+  expect_true("test_blueprint_initial" %in% plan$target)
+  expect_true("test_blueprint" %in% plan$target)
+  expect_true("test_subdir_blueprint_initial" %in% plan$target)
+  expect_true("test_subdir_blueprint" %in% plan$target)
 })


### PR DESCRIPTION
### Description of changes:
- Adds `recurse` parameter to `load_blueprints()` and `tar_blueprints()` to recursively load blueprints from the provided `directory`
- Adds `fs` package dependency

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
