### PR TITLE
Fix extraneous noise due to no parents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blueprintr
 Title: Automagically Document and Test Datasets Using Targets Or Drake
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: 
     c(person(given = "Patrick",
              family = "Anker",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# blueprintr 0.0.9
+
+* Bugfix to ensure the "description" field is present in the event that parent, annotated datasets don't have the "description" field filled in at all
+* Bugfix that didn't specify a join column, causing nuisance noise
+
 # blueprintr 0.0.8
 
 * Adds "annotations", a variable attribute system that makes it easier to propagate metadata provenance, rather than depending on variable naming from `.TARGET()` calls.

--- a/R/metadata-create.R
+++ b/R/metadata-create.R
@@ -51,6 +51,16 @@ propagate_metadata <- function(metadata_dt, df, deps_metalist) {
     metadata_dt <- decs_dt
   }
 
+  # Remove .origin if no reconciliation happened
+  if (".origin" %in% names(metadata_dt)) {
+    metadata_dt[[".origin"]] <- NULL
+  }
+
+  # Ensure "description" is available for metadata reqs
+  if (!"description" %in% names(metadata_dt)) {
+    metadata_dt[["description"]] <- NA_character_
+  }
+
   metadata_dt
 }
 
@@ -93,7 +103,8 @@ link_annotation_meta <- function(meta_dt, df) {
   meta_dt <- dplyr::select(meta_dt, .data$name, .data$type)
   meta_dt <- dplyr::left_join(
     meta_dt,
-    annotation_table_df(df)
+    annotation_table_df(df),
+    by = "name"
   )
   dplyr::mutate(
     meta_dt,

--- a/man/blueprintr-package.Rd
+++ b/man/blueprintr-package.Rd
@@ -4,7 +4,7 @@
 \name{blueprintr-package}
 \alias{blueprintr}
 \alias{blueprintr-package}
-\title{blueprintr: Automagically Document and Test Datasets Using Drake}
+\title{blueprintr: Automagically Document and Test Datasets Using Targets Or Drake}
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 

--- a/tests/testthat/test-01-dependencies.R
+++ b/tests/testthat/test-01-dependencies.R
@@ -142,3 +142,16 @@ test_that("Coalescing annotation vs. metafile deps works", {
     "continuous"
   )
 })
+
+test_that("Metadata propagation corner cases are covered", {
+  # 1. No dependencies being provided doesn't leave behind
+  #    ".origin" column
+  # 2. "description" field always exists
+  mtcars_meta <- initial_metadata_dt(mtcars)
+  meta_dt <- propagate_metadata(mtcars_meta, mtcars, list())
+
+  expect_true(!".origin" %in% names(meta_dt))
+  expect_true(all(
+    c("name", "type", "description") %in% names(meta_dt)
+  ))
+})


### PR DESCRIPTION
### Description of changes:
* Bugfix to ensure the "description" field is present in the event that parent, annotated datasets don't have the "description" field filled in at all
* Bugfix that didn't specify a join column, causing nuisance noise
* Bugfix removing widow ".origin" column

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
