### PR TITLE
Add .with_names to mutate_annotation_across() to create f(x, nx)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blueprintr
 Title: Automagically Document and Test Datasets Using Targets Or Drake
-Version: 0.0.9
+Version: 0.0.10
 Authors@R: 
     c(person(given = "Patrick",
              family = "Anker",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# blueprintr 0.0.10
+
+* Adds a `.with_names` parameter to `mutate_annotation_across` that, when `TRUE`, sends a column and its name as arguments to `.fn`.
+
 # blueprintr 0.0.9
 
 * Bugfix to ensure the "description" field is present in the event that parent, annotated datasets don't have the "description" field filled in at all

--- a/man/mutate_annotation.Rd
+++ b/man/mutate_annotation.Rd
@@ -12,6 +12,7 @@ mutate_annotation_across(
   .field,
   .fn,
   .cols = dplyr::everything(),
+  .with_names = FALSE,
   ...,
   .overwrite = TRUE
 )
@@ -33,9 +34,14 @@ Annotations have an overwriting guard by default, but since these functions
 are intentionally modifying the annotations, this parameter
 defaults to \code{TRUE}.}
 
-\item{.fn}{A function that takes in a vector, the currently selected variable}
+\item{.fn}{A function that takes in a vector and arbitrary arguments \code{...}
+If \code{.with_names} is \code{TRUE}, then \code{.fn} will be passed the vector \emph{and}
+the name of the vector, since it's often useful to compute on the metadata.}
 
 \item{.cols}{A tidyselect-compatible selection of variables to be edited}
+
+\item{.with_names}{If \code{TRUE}, passes a column \emph{and} its name as arguments to
+\code{.fn}}
 }
 \value{
 A \code{data.frame} with annotated columns
@@ -47,4 +53,19 @@ However, in the course of data aggregation, it can be common to
 perform massive transformations that would be cumbersome to
 document manually. This exposes a metadata-manipulation framework
 prior to metadata file creation, in the style of \code{dplyr::mutate}.
+}
+\examples{
+# Adds a "mean" annotation to 'mpg'
+mutate_annotation(mtcars, "mean", mpg = mean(mpg))
+
+# Adds a "mean" annotation to all variables in `mtcars`
+mutate_annotation_across(mtcars, "mean", .fn = mean)
+
+# Adds a "title" annotation that copies the column name
+mutate_annotation_across(
+  mtcars,
+  "title",
+  .fn = function(x, nx) nx,
+  .with_names = TRUE
+)
 }

--- a/tests/testthat/test-01-annotations.R
+++ b/tests/testthat/test-01-annotations.R
@@ -64,4 +64,13 @@ test_that("Mutate synonyms behave as expected", {
     expect_true(has_annotation(dat2[[vn]], "means"))
     expect_identical(annotation(dat2[[vn]], "means"), mean(dat2[[vn]]))
   }
+
+  # Demonstrates that variable names are successfully passed in
+  dat3 <- mutate_annotation_across(
+    mtcars, "title", .fn = function(x, nx) nx, .with_names = TRUE
+  )
+
+  for (vn in names(dat3)) {
+    expect_identical(vn, annotation(dat3[[vn]], "title"))
+  }
 })


### PR DESCRIPTION
### Description of changes:
- Adds a `.with_names` parameter to `mutate_annotation_across` that, when `TRUE`, sends a column and its name as arguments to `.fn`.
- Adds better docs for `mutate_annotation()` and `mutate_annotation_across()`

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
