### PR TITLE
Bugfixes: blueprint file loading and ignoring private metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .RData
 docs/
 inst/doc
+
+# State file stuff
+**/*.~lock*

--- a/R/cleanup-annotate.R
+++ b/R/cleanup-annotate.R
@@ -15,6 +15,7 @@ annotate_variables <- function(df, bp, meta) {
 annotate_variable <- function(x, varname, meta, overwrite) {
   meta <- dplyr::filter(meta, .data$name == varname)
   fields <- setdiff(names(meta), c("name", "type", "dropped"))
+  fields <- fields[!grepl("^\\.", fields)]
 
   for (f in fields) {
     x <- add_annotation(x, f, meta[[f]], overwrite)

--- a/R/load-blueprints.R
+++ b/R/load-blueprints.R
@@ -71,7 +71,7 @@ fetch_blueprint_files <- function(directory) {
 }
 
 import_blueprint_file <- function(bp_file, env = parent.frame()) {
-  exprs <- rlang::parse_exprs(file(bp_file))
+  exprs <- rlang::parse_exprs(file(bp_file, encoding = "UTF-8"))
   vals <- lapply(exprs, eval_tidy, env = env)
 
   if (length(vals) < 1) {

--- a/inst/blueprints/mtcars_chunk_rearranged_copy.csv
+++ b/inst/blueprints/mtcars_chunk_rearranged_copy.csv
@@ -1,0 +1,12 @@
+"name","description","type","coding","dropped","tests"
+"cyl","Number of cylinders","double","coding(code(""Four"", 4), code(""Six"", 6), code(""Eight"", 8))",,"in_set(c(4, 6, 8))"
+"mpg","Gas mileage","double",,,
+"disp",,"double",,,
+"hp",,"double",,,
+"drat",,"double",,,
+"wt",,"double",,,
+"qsec",,"double",,"TRUE",
+"vs",,"double",,"TRUE",
+"am",,"double",,"TRUE",
+"gear",,"double",,"TRUE",
+"carb",,"double",,"TRUE",

--- a/tests/testthat/test-02-cleanup.R
+++ b/tests/testthat/test-02-cleanup.R
@@ -52,10 +52,9 @@ test_that("Variables are converted to labelled vectors correctly", {
 
 test_that("Variables are annotated correctly", {
   mtcars_rearranged_bp <- blueprint(
-    "mtcars_chunk_rearranged",
+    "mtcars_chunk_rearranged_copy",
     command = mtcars,
     metadata_directory = bp_path("blueprints"),
-    labelled = TRUE,
     annotate = TRUE
   )
 
@@ -64,17 +63,21 @@ test_that("Variables are annotated correctly", {
   drake::clean()
   drake::make(plan)
 
-  drake::loadd(mtcars_chunk_rearranged)
+  drake::loadd(mtcars_chunk_rearranged_copy)
 
   expect_true(
-    has_annotation(mtcars_chunk_rearranged$cyl, "description")
+    has_annotation(mtcars_chunk_rearranged_copy$cyl, "description")
   )
 
   expect_true(
-    has_annotation(mtcars_chunk_rearranged$mpg, "description")
+    has_annotation(mtcars_chunk_rearranged_copy$mpg, "description")
   )
 
   expect_true(
-    has_annotation(mtcars_chunk_rearranged$cyl, "coding")
+    has_annotation(mtcars_chunk_rearranged_copy$cyl, "coding")
+  )
+
+  expect_false(
+    has_annotation(mtcars_chunk_rearranged_copy$cyl, ".parsed_tests")
   )
 })

--- a/tests/testthat/test-02-cleanup.R
+++ b/tests/testthat/test-02-cleanup.R
@@ -19,6 +19,8 @@ test_that("Variables are reordered and dropped correctly", {
 })
 
 test_that("Variables are converted to labelled vectors correctly", {
+  skip_if_not_installed("labelled")
+
   mtcars_rearranged_bp <- blueprint(
     "mtcars_chunk_rearranged",
     command = mtcars,

--- a/tests/testthat/test-03-codebook-export.R
+++ b/tests/testthat/test-03-codebook-export.R
@@ -53,6 +53,8 @@ test_that("Codebook exports are added to plan correctly", {
 })
 
 test_that("Codebooks are rendered safely", {
+  skip_if_not_installed("labelled")
+
   test_bp <- blueprint(
     "mtcars_chunk_rearranged",
     command = mtcars,

--- a/tests/testthat/test-03-import-mappingdf-data.R
+++ b/tests/testthat/test-03-import-mappingdf-data.R
@@ -56,6 +56,8 @@ test_that("mdf_keep_panel() works", {
 })
 
 test_that("mapped_df import works correctly", {
+  skip_if_not_installed("panelcleaner")
+
   # Make sure mdf_import_meta only runs on mapped_dfs
   meta_dt <- initial_metadata_dt(datasets::mtcars)
   expect_identical(


### PR DESCRIPTION
Addresses #40 and #41

### Description of changes:
- Blueprint file loading now uses UTF-8 encoding during parsing
- Ignores private (dot-prefixed) metadata fields during variable annotation

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
