### PR TITLE
Make sure bp_extend() doesn't override bp_add_bpstep()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blueprintr
 Title: Automagically Document and Test Datasets Using Targets Or Drake
-Version: 0.1.0.9000
+Version: 0.1.1
 Authors@R: 
     c(person(given = "Patrick",
              family = "Anker",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# Development version
+# blueprintr 0.1.1
 * Clarifies which coding string cannot be evaluated during codebook generation or labelling
+* Fixes a bug where `bp_extend()` would clobber the results of `bp_add_bpstep()` 
 
 # blueprintr 0.1.0
 * Adds capability to define custom pipeline steps, executed after completion of the `_final` stage

--- a/R/assembler.R
+++ b/R/assembler.R
@@ -112,7 +112,7 @@ add_assembly_step <- function(steps, step) {
     allow_duplicates <- step$allow_duplicates %||% FALSE
 
     if (step$step %in% step_names & !isTRUE(allow_duplicates)) {
-      bp_err("'{step$step}' already found in blueprint '{bp$name}' steps")
+      bp_err("'{step$step}' already found in blueprint '{step$blueprint$name}' steps") # nolint
     }
 
     steps[[length(steps) + 1]] <- step

--- a/R/blueprint.R
+++ b/R/blueprint.R
@@ -70,6 +70,7 @@ blueprint <- function(name,
       description = description,
       annotate = annotate,
       metadata_file_path = path,
+      extra_steps = extra_steps,
       ...
     ),
     class = c(class, "blueprint")

--- a/tests/testthat/test-03-blueprint-extensions.R
+++ b/tests/testthat/test-03-blueprint-extensions.R
@@ -64,3 +64,36 @@ test_that("Extra bpstep additions behave correctly", {
     )
   )
 })
+
+test_that("bp_extend() and bp_add_bpstep() don't break each other", {
+  test_bp <- blueprint(
+    "test_bp_1",
+    description = "dummy",
+    command = mtcars
+  )
+
+  bp1 <- bp_label_variables(bp_export_codebook(test_bp))
+  bp2 <- bp_export_codebook(bp_label_variables(test_bp))
+
+  expect_false(is.null(bp1$extra_steps))
+  expect_identical(length(bp1$extra_steps), length(bp2$extra_steps))
+
+  cb1 <- bp1$extra_steps[[1]]
+  cb2 <- bp2$extra_steps[[1]]
+
+  expect_identical(cb1$step, "export_codebook")
+  expect_identical(cb1$step, cb2$step)
+})
+
+test_that("Multiple steps make sense when applicable", {
+  test_bp <- blueprint(
+    "test_bp_1",
+    description = "dummy",
+    command = mtcars
+  )
+
+  expect_error(
+    bp_export_codebook(bp_export_codebook(test_bp)),
+    class = "bp_error"
+  )
+})

--- a/tests/testthat/test-03-codebook-export.R
+++ b/tests/testthat/test-03-codebook-export.R
@@ -83,3 +83,84 @@ test_that("Codebooks are rendered safely", {
   expect_true(!inherits(render_out, "error"))
   unlink(temp_file)
 })
+
+test_that("Codebook export step added correctly", {
+  test_bp <- blueprint(
+    "mtcars_chunk_rearranged",
+    command = mtcars,
+    metadata_directory = bp_path("blueprints")
+  )
+
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp
+  )
+
+  plan <- plan_from_blueprint(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% plan$target)
+
+  # Adding custom args
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp,
+    summaries = TRUE
+  )
+
+  plan <- plan_from_blueprint(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% plan$target)
+
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp,
+    file = here::here("testy.html")
+  )
+
+  plan <- plan_from_blueprint(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% plan$target)
+
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp,
+    title = "test"
+  )
+
+  plan <- plan_from_blueprint(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% plan$target)
+})
+
+test_that("targets attachment works", {
+  skip_if_not_installed("targets")
+
+  test_bp <- blueprint(
+    "mtcars_chunk_rearranged",
+    command = mtcars,
+    metadata_directory = bp_path("blueprints")
+  )
+
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp
+  )
+
+  tar_list <- tar_blueprint_raw(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% vcapply(tar_list, function(x) x$settings$name)) # nolint
+
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp,
+    summaries = TRUE
+  )
+
+  tar_list <- tar_blueprint_raw(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% vcapply(tar_list, function(x) x$settings$name)) # nolint
+
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp,
+    file = here::here("testy.html")
+  )
+
+  tar_list <- tar_blueprint_raw(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% vcapply(tar_list, function(x) x$settings$name)) # nolint
+
+  test_bp_with_cbexport <- bp_export_codebook(
+    test_bp,
+    title = "testy"
+  )
+
+  tar_list <- tar_blueprint_raw(test_bp_with_cbexport)
+  expect_true("mtcars_chunk_rearranged_codebook" %in% vcapply(tar_list, function(x) x$settings$name)) # nolint
+})


### PR DESCRIPTION
### Description of changes:
- Fixes a bug where `bp_extend()` would clobber the results of `bp_add_bpstep()`

### Requirements:
- [x] Does your PR include unit tests?
- [x] Does your PR pass `R CMD check` ?
- [x] If you made user-facing changes, did you update `NEWS.md` with a new bullet? Be sure to tag your name and relevant issue number like `* Made text more readable (@yourname, #1234)`
